### PR TITLE
Allow anonymous profile support

### DIFF
--- a/app/api/chat/openai/route.ts
+++ b/app/api/chat/openai/route.ts
@@ -45,7 +45,7 @@ export async function POST(request: Request) {
 
     if (errorMessage.toLowerCase().includes("api key not found")) {
       errorMessage =
-        "OpenAI API Key not found. Please set it in your profile settings."
+        "OpenAI API Key not found. Please set it in your profile settings or environment." 
     } else if (errorMessage.toLowerCase().includes("incorrect api key")) {
       errorMessage =
         "OpenAI API Key is incorrect. Please fix it in your profile settings."

--- a/lib/server/server-chat-helpers.ts
+++ b/lib/server/server-chat-helpers.ts
@@ -18,18 +18,21 @@ export async function getServerProfile() {
   )
 
   const user = (await supabase.auth.getUser()).data.user
-  if (!user) {
-    throw new Error("User not found")
+
+  let profile: Tables<"profiles"> | null = null
+
+  if (user) {
+    const { data } = await supabase
+      .from("profiles")
+      .select("*")
+      .eq("user_id", user.id)
+      .single()
+
+    profile = data as Tables<"profiles"> | null
   }
 
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("*")
-    .eq("user_id", user.id)
-    .single()
-
   if (!profile) {
-    throw new Error("Profile not found")
+    profile = { use_azure_openai: false } as Tables<"profiles">
   }
 
   const profileWithKeys = addApiKeysToProfile(profile)


### PR DESCRIPTION
## Summary
- return a fallback profile when no user is found
- clarify error message in the OpenAI chat route for missing API keys

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6886e5d9297c832bb1e076c0db0814de