### PR TITLE
Add simple rate limiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,9 @@ You can also add API keys as environment variables.
 - `AZURE_OPENAI_ENDPOINT`
 - `AZURE_GPT_45_VISION_NAME`
 
+If you expose these keys to users, they are shared across all requests. Consider
+configuring server-side rate limiting to avoid abuse and unexpected costs.
+
 For the full list of environment variables, refer to the '.env.local.example' file. If the environment variables are set for API keys, it will disable the input in the user settings.
 
 Click "Deploy" and wait for your frontend to deploy.

--- a/app/api/assistants/openai/route.ts
+++ b/app/api/assistants/openai/route.ts
@@ -1,4 +1,5 @@
 import { checkApiKey, getServerProfile } from "@/lib/server/server-chat-helpers"
+import { checkRateLimit } from "@/lib/server/rate-limit"
 import { ServerRuntime } from "next"
 import OpenAI from "openai"
 
@@ -7,6 +8,13 @@ export const runtime: ServerRuntime = "edge"
 export async function GET() {
   try {
     const profile = await getServerProfile()
+
+    if (!checkRateLimit(profile.user_id)) {
+      return new Response(
+        JSON.stringify({ message: "Rate limit exceeded" }),
+        { status: 429 }
+      )
+    }
 
     checkApiKey(profile.openai_api_key, "OpenAI")
 

--- a/app/api/chat/anthropic/route.ts
+++ b/app/api/chat/anthropic/route.ts
@@ -1,5 +1,6 @@
 import { CHAT_SETTING_LIMITS } from "@/lib/chat-setting-limits"
 import { checkApiKey, getServerProfile } from "@/lib/server/server-chat-helpers"
+import { checkRateLimit } from "@/lib/server/rate-limit"
 import { getBase64FromDataURL, getMediaTypeFromDataURL } from "@/lib/utils"
 import { ChatSettings } from "@/types"
 import Anthropic from "@anthropic-ai/sdk"
@@ -17,6 +18,13 @@ export async function POST(request: NextRequest) {
 
   try {
     const profile = await getServerProfile()
+
+    if (!checkRateLimit(profile.user_id)) {
+      return new NextResponse(
+        JSON.stringify({ message: "Rate limit exceeded" }),
+        { status: 429 }
+      )
+    }
 
     checkApiKey(profile.anthropic_api_key, "Anthropic")
 

--- a/app/api/chat/azure/route.ts
+++ b/app/api/chat/azure/route.ts
@@ -1,4 +1,5 @@
 import { checkApiKey, getServerProfile } from "@/lib/server/server-chat-helpers"
+import { checkRateLimit } from "@/lib/server/rate-limit"
 import { ChatAPIPayload } from "@/types"
 import { OpenAIStream, StreamingTextResponse } from "ai"
 import OpenAI from "openai"
@@ -12,6 +13,13 @@ export async function POST(request: Request) {
 
   try {
     const profile = await getServerProfile()
+
+    if (!checkRateLimit(profile.user_id)) {
+      return new Response(
+        JSON.stringify({ message: "Rate limit exceeded" }),
+        { status: 429 }
+      )
+    }
 
     checkApiKey(profile.azure_openai_api_key, "Azure OpenAI")
 

--- a/app/api/chat/custom/route.ts
+++ b/app/api/chat/custom/route.ts
@@ -5,6 +5,7 @@ import { OpenAIStream, StreamingTextResponse } from "ai"
 import { ServerRuntime } from "next"
 import OpenAI from "openai"
 import { ChatCompletionCreateParamsBase } from "openai/resources/chat/completions.mjs"
+import { checkRateLimit } from "@/lib/server/rate-limit"
 
 export const runtime: ServerRuntime = "edge"
 

--- a/app/api/chat/google/route.ts
+++ b/app/api/chat/google/route.ts
@@ -1,4 +1,5 @@
 import { checkApiKey, getServerProfile } from "@/lib/server/server-chat-helpers"
+import { checkRateLimit } from "@/lib/server/rate-limit"
 import { ChatSettings } from "@/types"
 import { GoogleGenerativeAI } from "@google/generative-ai"
 
@@ -13,6 +14,13 @@ export async function POST(request: Request) {
 
   try {
     const profile = await getServerProfile()
+
+    if (!checkRateLimit(profile.user_id)) {
+      return new Response(
+        JSON.stringify({ message: "Rate limit exceeded" }),
+        { status: 429 }
+      )
+    }
 
     checkApiKey(profile.google_gemini_api_key, "Google")
 

--- a/app/api/chat/groq/route.ts
+++ b/app/api/chat/groq/route.ts
@@ -1,5 +1,6 @@
 import { CHAT_SETTING_LIMITS } from "@/lib/chat-setting-limits"
 import { checkApiKey, getServerProfile } from "@/lib/server/server-chat-helpers"
+import { checkRateLimit } from "@/lib/server/rate-limit"
 import { ChatSettings } from "@/types"
 import { OpenAIStream, StreamingTextResponse } from "ai"
 import OpenAI from "openai"
@@ -14,6 +15,13 @@ export async function POST(request: Request) {
 
   try {
     const profile = await getServerProfile()
+
+    if (!checkRateLimit(profile.user_id)) {
+      return new Response(
+        JSON.stringify({ message: "Rate limit exceeded" }),
+        { status: 429 }
+      )
+    }
 
     checkApiKey(profile.groq_api_key, "G")
 

--- a/app/api/chat/mistral/route.ts
+++ b/app/api/chat/mistral/route.ts
@@ -1,5 +1,6 @@
 import { CHAT_SETTING_LIMITS } from "@/lib/chat-setting-limits"
 import { checkApiKey, getServerProfile } from "@/lib/server/server-chat-helpers"
+import { checkRateLimit } from "@/lib/server/rate-limit"
 import { ChatSettings } from "@/types"
 import { OpenAIStream, StreamingTextResponse } from "ai"
 import OpenAI from "openai"
@@ -15,6 +16,13 @@ export async function POST(request: Request) {
 
   try {
     const profile = await getServerProfile()
+
+    if (!checkRateLimit(profile.user_id)) {
+      return new Response(
+        JSON.stringify({ message: "Rate limit exceeded" }),
+        { status: 429 }
+      )
+    }
 
     checkApiKey(profile.mistral_api_key, "Mistral")
 

--- a/app/api/chat/openai/route.ts
+++ b/app/api/chat/openai/route.ts
@@ -1,4 +1,5 @@
 import { checkApiKey, getServerProfile } from "@/lib/server/server-chat-helpers"
+import { checkRateLimit } from "@/lib/server/rate-limit"
 import { ChatSettings } from "@/types"
 import { OpenAIStream, StreamingTextResponse } from "ai"
 import { ServerRuntime } from "next"
@@ -16,6 +17,13 @@ export async function POST(request: Request) {
 
   try {
     const profile = await getServerProfile()
+
+    if (!checkRateLimit(profile.user_id)) {
+      return new Response(
+        JSON.stringify({ message: "Rate limit exceeded" }),
+        { status: 429 }
+      )
+    }
 
     checkApiKey(profile.openai_api_key, "OpenAI")
 

--- a/app/api/chat/openrouter/route.ts
+++ b/app/api/chat/openrouter/route.ts
@@ -1,4 +1,5 @@
 import { checkApiKey, getServerProfile } from "@/lib/server/server-chat-helpers"
+import { checkRateLimit } from "@/lib/server/rate-limit"
 import { ChatSettings } from "@/types"
 import { OpenAIStream, StreamingTextResponse } from "ai"
 import { ServerRuntime } from "next"
@@ -16,6 +17,13 @@ export async function POST(request: Request) {
 
   try {
     const profile = await getServerProfile()
+
+    if (!checkRateLimit(profile.user_id)) {
+      return new Response(
+        JSON.stringify({ message: "Rate limit exceeded" }),
+        { status: 429 }
+      )
+    }
 
     checkApiKey(profile.openrouter_api_key, "OpenRouter")
 

--- a/app/api/chat/perplexity/route.ts
+++ b/app/api/chat/perplexity/route.ts
@@ -1,4 +1,5 @@
 import { checkApiKey, getServerProfile } from "@/lib/server/server-chat-helpers"
+import { checkRateLimit } from "@/lib/server/rate-limit"
 import { ChatSettings } from "@/types"
 import { OpenAIStream, StreamingTextResponse } from "ai"
 import OpenAI from "openai"
@@ -14,6 +15,13 @@ export async function POST(request: Request) {
 
   try {
     const profile = await getServerProfile()
+
+    if (!checkRateLimit(profile.user_id)) {
+      return new Response(
+        JSON.stringify({ message: "Rate limit exceeded" }),
+        { status: 429 }
+      )
+    }
 
     checkApiKey(profile.perplexity_api_key, "Perplexity")
 

--- a/app/api/chat/tools/route.ts
+++ b/app/api/chat/tools/route.ts
@@ -1,5 +1,6 @@
 import { openapiToFunctions } from "@/lib/openapi-conversion"
 import { checkApiKey, getServerProfile } from "@/lib/server/server-chat-helpers"
+import { checkRateLimit } from "@/lib/server/rate-limit"
 import { Tables } from "@/supabase/types"
 import { ChatSettings } from "@/types"
 import { OpenAIStream, StreamingTextResponse } from "ai"
@@ -16,6 +17,13 @@ export async function POST(request: Request) {
 
   try {
     const profile = await getServerProfile()
+
+    if (!checkRateLimit(profile.user_id)) {
+      return new Response(
+        JSON.stringify({ message: "Rate limit exceeded" }),
+        { status: 429 }
+      )
+    }
 
     checkApiKey(profile.openai_api_key, "OpenAI")
 

--- a/app/api/command/route.ts
+++ b/app/api/command/route.ts
@@ -1,5 +1,6 @@
 import { CHAT_SETTING_LIMITS } from "@/lib/chat-setting-limits"
 import { checkApiKey, getServerProfile } from "@/lib/server/server-chat-helpers"
+import { checkRateLimit } from "@/lib/server/rate-limit"
 import OpenAI from "openai"
 
 export const runtime = "edge"
@@ -12,6 +13,13 @@ export async function POST(request: Request) {
 
   try {
     const profile = await getServerProfile()
+
+    if (!checkRateLimit(profile.user_id)) {
+      return new Response(
+        JSON.stringify({ message: "Rate limit exceeded" }),
+        { status: 429 }
+      )
+    }
 
     checkApiKey(profile.openai_api_key, "OpenAI")
 

--- a/app/api/retrieval/process/docx/route.ts
+++ b/app/api/retrieval/process/docx/route.ts
@@ -6,6 +6,7 @@ import { FileItemChunk } from "@/types"
 import { createClient } from "@supabase/supabase-js"
 import { NextResponse } from "next/server"
 import OpenAI from "openai"
+import { checkRateLimit } from "@/lib/server/rate-limit"
 
 export async function POST(req: Request) {
   const json = await req.json()
@@ -23,6 +24,13 @@ export async function POST(req: Request) {
     )
 
     const profile = await getServerProfile()
+
+    if (!checkRateLimit(profile.user_id)) {
+      return new NextResponse(
+        JSON.stringify({ message: "Rate limit exceeded" }),
+        { status: 429 }
+      )
+    }
 
     if (embeddingsProvider === "openai") {
       if (profile.use_azure_openai) {

--- a/app/api/retrieval/process/route.ts
+++ b/app/api/retrieval/process/route.ts
@@ -12,6 +12,7 @@ import { FileItemChunk } from "@/types"
 import { createClient } from "@supabase/supabase-js"
 import { NextResponse } from "next/server"
 import OpenAI from "openai"
+import { checkRateLimit } from "@/lib/server/rate-limit"
 
 export async function POST(req: Request) {
   try {
@@ -21,6 +22,13 @@ export async function POST(req: Request) {
     )
 
     const profile = await getServerProfile()
+
+    if (!checkRateLimit(profile.user_id)) {
+      return new NextResponse(
+        JSON.stringify({ message: "Rate limit exceeded" }),
+        { status: 429 }
+      )
+    }
 
     const formData = await req.formData()
 

--- a/app/api/retrieval/retrieve/route.ts
+++ b/app/api/retrieval/retrieve/route.ts
@@ -1,5 +1,6 @@
 import { generateLocalEmbedding } from "@/lib/generate-local-embedding"
 import { checkApiKey, getServerProfile } from "@/lib/server/server-chat-helpers"
+import { checkRateLimit } from "@/lib/server/rate-limit"
 import { Database } from "@/supabase/types"
 import { createClient } from "@supabase/supabase-js"
 import OpenAI from "openai"
@@ -22,6 +23,13 @@ export async function POST(request: Request) {
     )
 
     const profile = await getServerProfile()
+
+    if (!checkRateLimit(profile.user_id)) {
+      return new Response(
+        JSON.stringify({ message: "Rate limit exceeded" }),
+        { status: 429 }
+      )
+    }
 
     if (embeddingsProvider === "openai") {
       if (profile.use_azure_openai) {

--- a/lib/server/rate-limit.ts
+++ b/lib/server/rate-limit.ts
@@ -1,0 +1,33 @@
+export interface RateLimitOptions {
+  windowMs?: number
+  limit?: number
+}
+
+const DEFAULT_WINDOW_MS = 60 * 1000 // 1 minute
+const DEFAULT_LIMIT = 30
+
+interface Entry {
+  count: number
+  start: number
+}
+
+const requests = new Map<string, Entry>()
+
+export function checkRateLimit(
+  key: string,
+  { windowMs = DEFAULT_WINDOW_MS, limit = DEFAULT_LIMIT }: RateLimitOptions = {}
+): boolean {
+  const now = Date.now()
+  const entry = requests.get(key)
+  if (!entry || now - entry.start > windowMs) {
+    requests.set(key, { count: 1, start: now })
+    return true
+  }
+
+  if (entry.count >= limit) {
+    return false
+  }
+
+  entry.count += 1
+  return true
+}


### PR DESCRIPTION
## Summary
- add server-side rate limiting helper
- enforce quotas across hosted chat routes
- mention shared key risk in README

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: internet disabled)*

------
https://chatgpt.com/codex/tasks/task_b_6886e5dd6e5c832b9c23cc43500440d8